### PR TITLE
Adapt data preprocess and loading to the new ADT data format

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,7 @@ This repo contains the implementation of our recent work, EgoLifter: Open-world 
 ### Clone the repo
 
 ```bash
-git clone --recursive git@github.com:facebookresearch/egolifter.git
-
-# Or run the following if you forget the `--recursive` flag
-git submodule update --init --recursive
+git clone git@github.com:facebookresearch/egolifter.git
 ```
 
 ### Setup the environment and install packages. 
@@ -105,9 +102,9 @@ Environment variables in `source setup_env.bash` are needed for some scripts in 
 
 ### Download and Pre-processing
 
-First access ADT through this [link](https://www.projectaria.com/datasets/adt/) and download the `aria_digital_twin_dataset_download_urls.json` file, which contains the download links for the dataset. 
+First access ADT through this [link](https://www.projectaria.com/datasets/adt/) and download the `ADT_download_urls.json` file, which contains the download links for the dataset. 
 
-Then prepare a directory where you want to save the downloaded and processed dataset as follows. And put the `aria_digital_twin_dataset_download_urls.json` in the `$ADT_DATA_ROOT` directory. 
+Then prepare a directory where you want to save the downloaded and processed dataset as follows. And put the `ADT_download_urls.json` in the `$ADT_DATA_ROOT` directory. 
 
 ```bash
 # TODO: Change the following to directories where you want to save the dataset
@@ -117,7 +114,7 @@ export ADT_PROCESSED_ROOT=/path/to/adt_processed
 mkdir -p $ADT_DATA_ROOT
 mkdir -p $ADT_PROCESSED_ROOT
 
-cp /path/to/aria_digital_twin_dataset_download_urls.json $ADT_DATA_ROOT
+cp /path/to/ADT_download_urls.json $ADT_DATA_ROOT
 ```
 
 Then run the following script to download and process the dataset. 

--- a/scripts/download_process_adt.bash
+++ b/scripts/download_process_adt.bash
@@ -13,32 +13,67 @@ set -e
 cp assets/vignette_imx577.png ${ADT_DATA_ROOT} # Vignette image for the RGB camera
 cp assets/vignette_ov7251.png ${ADT_DATA_ROOT} # Vignette image for the SLAM camera
 
-# Names of the scenes used in ADT benchmark in EgoLifter
+# The data format for ADT dataset has recently changed. See this link:
+# https://github.com/facebookresearch/projectaria_tools/blob/main/projects/AriaDigitalTwinDatasetTools/data_provider/AriaDigitalTwinDataPathsProvider.h#L38
+
+# scene names using the old data format
+# declare -a SCENE_NAMES=(
+#     "Apartment_release_multiskeleton_party_seq121"
+#     "Apartment_release_multiskeleton_party_seq122"
+#     "Apartment_release_multiskeleton_party_seq123"
+#     "Apartment_release_multiskeleton_party_seq125"
+#     "Apartment_release_multiskeleton_party_seq126"
+#     "Apartment_release_multiskeleton_party_seq127"
+#     "Apartment_release_decoration_skeleton_seq137"
+#     "Apartment_release_meal_skeleton_seq136"
+#     "Apartment_release_multiuser_clean_seq116"
+#     "Apartment_release_multiuser_cook_seq114"
+#     "Apartment_release_multiuser_cook_seq143"
+#     "Apartment_release_multiuser_meal_seq132"
+#     "Apartment_release_multiuser_meal_seq140"
+#     "Apartment_release_multiuser_party_seq140"
+#     "Apartment_release_work_skeleton_seq131"
+#     "Apartment_release_work_skeleton_seq140"
+# )
+
+# scene names using the new format
 declare -a SCENE_NAMES=(
-    "Apartment_release_multiskeleton_party_seq121"
-    "Apartment_release_multiskeleton_party_seq122"
-    "Apartment_release_multiskeleton_party_seq123"
-    "Apartment_release_multiskeleton_party_seq125"
-    "Apartment_release_multiskeleton_party_seq126"
-    "Apartment_release_multiskeleton_party_seq127"
-    "Apartment_release_decoration_skeleton_seq137"
-    "Apartment_release_meal_skeleton_seq136"
-    "Apartment_release_multiuser_clean_seq116"
-    "Apartment_release_multiuser_cook_seq114"
-    "Apartment_release_multiuser_cook_seq143"
-    "Apartment_release_multiuser_meal_seq132"
-    "Apartment_release_multiuser_meal_seq140"
-    "Apartment_release_multiuser_party_seq140"
-    "Apartment_release_work_skeleton_seq131"
-    "Apartment_release_work_skeleton_seq140"
+    "Apartment_release_multiskeleton_party_seq121_71292"
+    "Apartment_release_multiskeleton_party_seq121_M1292"
+    "Apartment_release_multiskeleton_party_seq122_71292"
+    "Apartment_release_multiskeleton_party_seq122_M1292"
+    "Apartment_release_multiskeleton_party_seq123_71292"
+    "Apartment_release_multiskeleton_party_seq123_M1292"
+    "Apartment_release_multiskeleton_party_seq125_71292"
+    "Apartment_release_multiskeleton_party_seq125_M1292"
+    "Apartment_release_multiskeleton_party_seq126_71292"
+    "Apartment_release_multiskeleton_party_seq126_M1292"
+    "Apartment_release_multiskeleton_party_seq127_71292"
+    "Apartment_release_multiskeleton_party_seq127_M1292"
+    "Apartment_release_decoration_skeleton_seq137_M1292"
+    "Apartment_release_meal_skeleton_seq136_M1292"
+    "Apartment_release_multiuser_clean_seq116_M1292"
+    "Apartment_release_multiuser_cook_seq114_M1292"
+    "Apartment_release_multiuser_cook_seq143_M1292"
+    "Apartment_release_multiuser_meal_seq132_M1292"
+    "Apartment_release_multiuser_meal_seq140_M1292"
+    "Apartment_release_multiuser_party_seq140_M1292"
+    "Apartment_release_work_skeleton_seq131_M1292"
+    "Apartment_release_work_skeleton_seq140_M1292"
+)
+
+# **TODO**: only for debugging, remove this before merging to main branch
+declare -a SCENE_NAMES=(
+    "Apartment_release_multiskeleton_party_seq121_71292"
+    "Apartment_release_multiskeleton_party_seq121_M1292"
 )
 
 # Download
 for SCENE_NAME in "${SCENE_NAMES[@]}"; do
-    adt_benchmark_dataset_downloader \
-        -c ${ADT_DATA_ROOT}/aria_digital_twin_dataset_download_urls.json \
+    aria_dataset_downloader \
+        -c ${ADT_DATA_ROOT}/ADT_download_urls.json \
         -o ${ADT_DATA_ROOT}/ \
-        -d 0 1 5 6 \
+        -d 0 1 2 3 6 7 \
         -l ${SCENE_NAME}
 done
 

--- a/scripts/download_process_adt.bash
+++ b/scripts/download_process_adt.bash
@@ -17,27 +17,27 @@ cp assets/vignette_ov7251.png ${ADT_DATA_ROOT} # Vignette image for the SLAM cam
 # https://github.com/facebookresearch/projectaria_tools/blob/main/projects/AriaDigitalTwinDatasetTools/data_provider/AriaDigitalTwinDataPathsProvider.h#L38
 
 # scene names using the old data format
-# declare -a SCENE_NAMES=(
-#     "Apartment_release_multiskeleton_party_seq121"
-#     "Apartment_release_multiskeleton_party_seq122"
-#     "Apartment_release_multiskeleton_party_seq123"
-#     "Apartment_release_multiskeleton_party_seq125"
-#     "Apartment_release_multiskeleton_party_seq126"
-#     "Apartment_release_multiskeleton_party_seq127"
-#     "Apartment_release_decoration_skeleton_seq137"
-#     "Apartment_release_meal_skeleton_seq136"
-#     "Apartment_release_multiuser_clean_seq116"
-#     "Apartment_release_multiuser_cook_seq114"
-#     "Apartment_release_multiuser_cook_seq143"
-#     "Apartment_release_multiuser_meal_seq132"
-#     "Apartment_release_multiuser_meal_seq140"
-#     "Apartment_release_multiuser_party_seq140"
-#     "Apartment_release_work_skeleton_seq131"
-#     "Apartment_release_work_skeleton_seq140"
-# )
-
-# scene names using the new format
 declare -a SCENE_NAMES=(
+    "Apartment_release_multiskeleton_party_seq121"
+    "Apartment_release_multiskeleton_party_seq122"
+    "Apartment_release_multiskeleton_party_seq123"
+    "Apartment_release_multiskeleton_party_seq125"
+    "Apartment_release_multiskeleton_party_seq126"
+    "Apartment_release_multiskeleton_party_seq127"
+    "Apartment_release_decoration_skeleton_seq137"
+    "Apartment_release_meal_skeleton_seq136"
+    "Apartment_release_multiuser_clean_seq116"
+    "Apartment_release_multiuser_cook_seq114"
+    "Apartment_release_multiuser_cook_seq143"
+    "Apartment_release_multiuser_meal_seq132"
+    "Apartment_release_multiuser_meal_seq140"
+    "Apartment_release_multiuser_party_seq140"
+    "Apartment_release_work_skeleton_seq131"
+    "Apartment_release_work_skeleton_seq140"
+)
+
+# scene names using the new format, only used for downloading script
+declare -a SCENE_NAMES_NEW=(
     "Apartment_release_multiskeleton_party_seq121_71292"
     "Apartment_release_multiskeleton_party_seq121_M1292"
     "Apartment_release_multiskeleton_party_seq122_71292"
@@ -62,14 +62,17 @@ declare -a SCENE_NAMES=(
     "Apartment_release_work_skeleton_seq140_M1292"
 )
 
-# **TODO**: only for debugging, remove this before merging to main branch
-declare -a SCENE_NAMES=(
-    "Apartment_release_multiskeleton_party_seq121_71292"
-    "Apartment_release_multiskeleton_party_seq121_M1292"
-)
+# # Only for debugging
+# declare -a SCENE_NAMES_NEW=(
+#     "Apartment_release_multiskeleton_party_seq121_71292"
+#     "Apartment_release_multiskeleton_party_seq121_M1292"
+# )
+# declare -a SCENE_NAMES=(
+#     "Apartment_release_multiskeleton_party_seq121"
+# )
 
 # Download
-for SCENE_NAME in "${SCENE_NAMES[@]}"; do
+for SCENE_NAME in "${SCENE_NAMES_NEW[@]}"; do
     aria_dataset_downloader \
         -c ${ADT_DATA_ROOT}/ADT_download_urls.json \
         -o ${ADT_DATA_ROOT}/ \

--- a/scripts/generate_3dbox_query.py
+++ b/scripts/generate_3dbox_query.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import glob
 import os, sys
 
 import json
@@ -49,8 +50,6 @@ class Generate3dboxQuery:
     data_root: Path
     scene_name: str
 
-    selected_device_number: int = 0
-    
     seed: int = 42
     
     def main(self) -> None:
@@ -65,10 +64,13 @@ class Generate3dboxQuery:
                 instance_ids_queried.add(int(instance_id))
         
         # Load the object pose information from the raw data folder
+        # Handle the new data format, where each device recording has its sequence. 
         raw_folder = self.raw_root / self.scene_name
-        paths_provider = AriaDigitalTwinDataPathsProvider(str(raw_folder))
+        subseq_paths = sorted(glob.glob(str(raw_folder) + "_*"))
+        assert len(subseq_paths) > 0, f"No subsequence found in {raw_folder}"
+        paths_provider = AriaDigitalTwinDataPathsProvider(subseq_paths[0])
         
-        data_paths = paths_provider.get_datapaths_by_device_num(self.selected_device_number, skeleton_flag=True)
+        data_paths = paths_provider.get_datapaths(skeleton_flag=False)
         gt_provider = AriaDigitalTwinDataProvider(data_paths)
         
         stream_id = StreamId("214-1")

--- a/scripts/generate_gsa_results.py
+++ b/scripts/generate_gsa_results.py
@@ -214,7 +214,7 @@ def vis_result_fast(
     image: np.ndarray, 
     detections: sv.Detections, 
     classes: list[str], 
-    color: Color | ColorPalette = ColorPalette.default(), 
+    color: Color | ColorPalette = ColorPalette.DEFAULT, 
     instance_random_color: bool = False,
     draw_bbox: bool = True,
 ) -> np.ndarray:
@@ -223,7 +223,7 @@ def vis_result_fast(
     This is fast but of the same resolution of the input image, thus can be blurry. 
     '''
     # annotate image with detections
-    box_annotator = sv.BoundingBoxAnnotator(
+    box_annotator = sv.BoxAnnotator(
         color = color,
     )
     label_annontator = sv.LabelAnnotator(

--- a/scripts/process_adt_3dgs.py
+++ b/scripts/process_adt_3dgs.py
@@ -149,6 +149,7 @@ class ProcessAriaDigitalTwin:
         
         # Initialize the data provider for this sequence
         paths_provider = AriaDigitalTwinDataPathsProvider(str(sequence_path))
+        
         all_device_serials = paths_provider.get_device_serial_numbers()
 
         print("all devices for sequence ", sequence_name, ":")
@@ -160,7 +161,11 @@ class ProcessAriaDigitalTwin:
         for selected_device_number in range(len(all_device_serials)):
             print("processing device number: ", selected_device_number)
             
-            data_paths = paths_provider.get_datapaths_by_device_num(selected_device_number, skeleton_flag=True)
+            # In the newest data format, the segmentations_with_skeleton.vrs file is somehow not included. 
+            # Raised an issue here: https://github.com/facebookresearch/projectaria_tools/issues/142
+            # data_paths = paths_provider.get_datapaths_by_device_num(selected_device_number, skeleton_flag=True)
+            data_paths = paths_provider.get_datapaths_by_device_num(selected_device_number, skeleton_flag=False)
+
             gt_provider = AriaDigitalTwinDataProvider(data_paths)
             
             os.makedirs(output_folder, exist_ok=True)
@@ -357,6 +362,7 @@ class ProcessAriaDigitalTwin:
                     "vignette_subpath": vignette_save_subpath,
                     "mask_subpath": mask_save_subpath,
                 })
+                
 
             print(f"There are {len(output_frame_metadata_device)}/{len(img_timestamps_ns)} valid frames in the output.")
             output_frame_metadata.extend(output_frame_metadata_device)

--- a/scripts/process_adt_3dgs.py
+++ b/scripts/process_adt_3dgs.py
@@ -147,24 +147,32 @@ class ProcessAriaDigitalTwin:
         output_folder = self.output_root / sequence_name
         
         
-        # Initialize the data provider for this sequence
-        paths_provider = AriaDigitalTwinDataPathsProvider(str(sequence_path))
+        # Old data hierarchy: sequences - device - data
+        # New data hierarchy: sequences - data
+        # Now each sequence only contains one device. In this script, still keep the old data hierarchy.
+        # See: https://github.com/facebookresearch/projectaria_tools/blob/main/projects/AriaDigitalTwinDatasetTools/data_provider/AriaDigitalTwinDataPathsProvider.h#L38
+        subseq_paths = sorted(glob.glob(str(sequence_path) + "_*"))
         
-        all_device_serials = paths_provider.get_device_serial_numbers()
-
-        print("all devices for sequence ", sequence_name, ":")
-        for idx, device_serial in enumerate(all_device_serials):
-            print("device number - ", idx, ": ", device_serial)
+        assert len(subseq_paths) > 0, "No subsequence found!"
+        
+        paths_providers = []
+        for subseq_path in subseq_paths:
+            # Initialize the data provider for this sequence
+            paths_provider = AriaDigitalTwinDataPathsProvider(subseq_path)
+            paths_providers.append(paths_provider)
             
+            subseq_device_serials = paths_provider.get_device_serial_numbers()
+            assert len(subseq_device_serials) == 1, f"More than one devices found in the subsequence: {subseq_device_serials}"
         
         output_frame_metadata = []
-        for selected_device_number in range(len(all_device_serials)):
-            print("processing device number: ", selected_device_number)
+        for selected_device_number in range(len(subseq_paths)):
+            print(f"Processing sequence {subseq_paths[selected_device_number]}")
+            paths_provider = paths_providers[selected_device_number]
             
             # In the newest data format, the segmentations_with_skeleton.vrs file is somehow not included. 
             # Raised an issue here: https://github.com/facebookresearch/projectaria_tools/issues/142
             # data_paths = paths_provider.get_datapaths_by_device_num(selected_device_number, skeleton_flag=True)
-            data_paths = paths_provider.get_datapaths_by_device_num(selected_device_number, skeleton_flag=False)
+            data_paths = paths_provider.get_datapaths(skeleton_flag=False)
 
             gt_provider = AriaDigitalTwinDataProvider(data_paths)
             

--- a/scripts/process_adt_3dgs.py
+++ b/scripts/process_adt_3dgs.py
@@ -169,10 +169,8 @@ class ProcessAriaDigitalTwin:
             print(f"Processing sequence {subseq_paths[selected_device_number]}")
             paths_provider = paths_providers[selected_device_number]
             
-            # In the newest data format, the segmentations_with_skeleton.vrs file is somehow not included. 
-            # Raised an issue here: https://github.com/facebookresearch/projectaria_tools/issues/142
-            # data_paths = paths_provider.get_datapaths_by_device_num(selected_device_number, skeleton_flag=True)
-            data_paths = paths_provider.get_datapaths(skeleton_flag=False)
+            # In the newest dataset format, each sequence only includes one device
+            data_paths = paths_provider.get_datapaths(skeleton_flag=True)
 
             gt_provider = AriaDigitalTwinDataProvider(data_paths)
             


### PR DESCRIPTION
The ADT dataset format has been changed in a recent update. See the details [here](https://github.com/facebookresearch/projectaria_tools/blob/main/projects/AriaDigitalTwinDatasetTools/data_provider/AriaDigitalTwinDataPathsProvider.h#L38). 

This PR fixed the #3. See the issue for more details. 